### PR TITLE
fix(): add default max size of dots

### DIFF
--- a/app/components/home/Map.tsx
+++ b/app/components/home/Map.tsx
@@ -28,13 +28,14 @@ const sizes: Record<number, number> = {
   7: 2.75,
   8: 3,
 }
+const maxSize = 3.25
 
 const Country = ({ flag, country, x, y, code }: typeof countries[number]) => {
   const size = perCountry.get(code) ?? 0
   return (
     <div
       className={`group aspect-square absolute rounded-full bg-highlight-on hover:bg-white hover:scale-125 animation ease-in-all duration-200 flex justify-center align-items hover:z-50 font-light text-xl`}
-      style={{ left: x, top: y, width: `${sizes[size]}%` }}
+      style={{ left: x, top: y, width: `${sizes[size] ? sizes[size] : maxSize}%` }}
     >
       <div className="hidden group-hover:flex flex-col whitespace-nowrap absolute -top-full p-2 gap-2 rounded-sm bg-dark-300 text-sm z-10">
         <span>


### PR DESCRIPTION
With one of the teams reaching size of 9, its dot became missing from the map as the predefined `sizes` array was populated only to account for max 8.
Added a default maximal size as enlarging the dots further could end up with them covering up eachother and it would have to be constantly updated as teams grow.